### PR TITLE
'indexing: false' feature support

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -84,7 +84,7 @@ module.exports = function (hexo) {
     function postFilter(language) {
         return function (post) {
             let lang = getPageLanguage(post);
-            return lang === language || (isDefaultLanguage(language) && !lang);
+            return (lang === language || (isDefaultLanguage(language) && !lang)) && (post.indexing !== false);
         }
     }
 


### PR DESCRIPTION
InSight search will not index pages with  `indexing: false` added in front matter.