### PR TITLE
Fix: Error when generating static files due to safeLoad removed in js-yaml 4

### DIFF
--- a/scripts/99_config.js
+++ b/scripts/99_config.js
@@ -30,7 +30,7 @@ function getThemeConfig(lang = null) {
         if (!altConfigs.hasOwnProperty(lang)) {
             const configPath = path.join(themeRoot, '_config.' + lang + '.yml');
             if (fs.existsSync(configPath)) {
-                const config = yaml.safeLoad(fs.readFileSync(configPath));
+                const config = yaml.load(fs.readFileSync(configPath));
                 if (config != null) {
                     altConfigs[lang] = config;
                 }


### PR DESCRIPTION
Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.

Hexo has switched to js-yaml 4.0.0 since 5.4.0